### PR TITLE
Adapting image scale to avoid lost of image pixels

### DIFF
--- a/UIImage+Trim.h
+++ b/UIImage+Trim.h
@@ -12,5 +12,6 @@
 @interface UIImage (Trim)
 
 - (UIImage*)imageByTrimmingTransparentPixels;
+- (UIImage *) imageByTrimmingTransparentPixelsWithMargin:(UIEdgeInsets)insets;
 
 @end

--- a/UIImage+Trim.m
+++ b/UIImage+Trim.m
@@ -13,8 +13,8 @@
 
 - (UIImage *) imageByTrimmingTransparentPixels
 {
-	int rows = self.size.height;
-	int cols = self.size.width;
+	int rows = self.size.height * self.scale;
+	int cols = self.size.width * self.scale;
 	int bytesPerRow = cols*sizeof(uint8_t);
 	
 	if ( rows < 2 || cols < 2 )
@@ -116,7 +116,7 @@
 		CGImageRef newImage = CGImageCreateWithImageInRect(cgImage, rect);
 		
 		// Convert back to UIImage
-        img = [UIImage imageWithCGImage:newImage];
+        img = [UIImage imageWithCGImage:newImage scale:self.scale orientation:self.imageOrientation];
         
         CGImageRelease(newImage);
 	}

--- a/UIImage+Trim.m
+++ b/UIImage+Trim.m
@@ -11,7 +11,11 @@
 
 @implementation UIImage (Trim)
 
-- (UIImage *) imageByTrimmingTransparentPixels
+- (UIImage *) imageByTrimmingTransparentPixels {
+    return [self imageByTrimmingTransparentPixelsWithMargin:UIEdgeInsetsZero];
+}
+
+- (UIImage *) imageByTrimmingTransparentPixelsWithMargin:(UIEdgeInsets)insets
 {
 	int rows = self.size.height * self.scale;
 	int cols = self.size.width * self.scale;
@@ -106,6 +110,11 @@
 	}
 	else
     {
+        crop.top = MAX(crop.top-insets.top, 0);
+        crop.bottom = MAX(crop.bottom-insets.bottom, 0);
+        crop.left = MAX(crop.left-insets.left, 0);
+        crop.right = MAX(crop.right-insets.right, 0);
+
 		// Calculate new crop bounds
 		rect.origin.x += crop.left;
 		rect.origin.y += crop.top;


### PR DESCRIPTION
If image is scale 2 or another scale, original method doesn't work well. So I will make small change to consider image scale when it create bitmap and when it creates adjusted UIImage. 
